### PR TITLE
rgw: add ability to track reshard stats

### DIFF
--- a/ceph/cluster_usage_test.go
+++ b/ceph/cluster_usage_test.go
@@ -15,7 +15,7 @@
 package ceph
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -155,7 +155,7 @@ func TestClusterUsage(t *testing.T) {
 			require.NoError(t, err)
 			defer resp.Body.Close()
 
-			buf, err := ioutil.ReadAll(resp.Body)
+			buf, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 
 			for _, re := range tt.reMatch {

--- a/ceph/crashes_test.go
+++ b/ceph/crashes_test.go
@@ -15,7 +15,7 @@
 package ceph
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -209,7 +209,7 @@ func TestCrashesCollector(t *testing.T) {
 				require.NoError(t, err)
 				defer resp.Body.Close()
 
-				buf, err := ioutil.ReadAll(resp.Body)
+				buf, err := io.ReadAll(resp.Body)
 				require.NoError(t, err)
 
 				for _, re := range tt.reMatch {

--- a/ceph/exporter.go
+++ b/ceph/exporter.go
@@ -181,9 +181,7 @@ func (exporter *Exporter) setRbdMirror() error {
 		}
 	} else {
 		// remove the rbdMirror collector if present
-		if _, ok := exporter.cc["rbdMirror"]; ok {
-			delete(exporter.cc, "rbdMirror")
-		}
+		delete(exporter.cc, "rbdMirror")
 	}
 
 	return nil

--- a/ceph/health_test.go
+++ b/ceph/health_test.go
@@ -15,7 +15,7 @@
 package ceph
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -835,7 +835,7 @@ $ sudo ceph -s
 			require.NoError(t, err)
 			defer resp.Body.Close()
 
-			buf, err := ioutil.ReadAll(resp.Body)
+			buf, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 
 			for _, re := range tt.reMatch {

--- a/ceph/monitors_test.go
+++ b/ceph/monitors_test.go
@@ -15,7 +15,7 @@
 package ceph
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -108,7 +108,7 @@ func TestMonitorCollector(t *testing.T) {
 			require.NoError(t, err)
 			defer resp.Body.Close()
 
-			buf, err := ioutil.ReadAll(resp.Body)
+			buf, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 
 			for _, re := range tt.regexes {
@@ -239,7 +239,7 @@ func TestMonitorTimeSyncStats(t *testing.T) {
 			require.NoError(t, err)
 			defer resp.Body.Close()
 
-			buf, err := ioutil.ReadAll(resp.Body)
+			buf, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 
 			for _, re := range tt.reMatch {
@@ -306,7 +306,7 @@ func TestMonitorCephVersions(t *testing.T) {
 			require.NoError(t, err)
 			defer resp.Body.Close()
 
-			buf, err := ioutil.ReadAll(resp.Body)
+			buf, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 
 			for _, re := range tt.reMatch {
@@ -392,7 +392,7 @@ func TestMonitorCephFeatures(t *testing.T) {
 			require.NoError(t, err)
 			defer resp.Body.Close()
 
-			buf, err := ioutil.ReadAll(resp.Body)
+			buf, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 
 			for _, re := range tt.reMatch {

--- a/ceph/osd_test.go
+++ b/ceph/osd_test.go
@@ -16,7 +16,7 @@ package ceph
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -1036,7 +1036,7 @@ func TestOSDCollector(t *testing.T) {
 			require.NoError(t, err)
 			defer resp.Body.Close()
 
-			buf, err := ioutil.ReadAll(resp.Body)
+			buf, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 
 			for _, re := range append(reMatch, tt.reMatch...) {

--- a/ceph/pool_test.go
+++ b/ceph/pool_test.go
@@ -17,7 +17,7 @@ package ceph
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -198,7 +198,7 @@ func TestPoolInfoCollector(t *testing.T) {
 			require.NoError(t, err)
 			defer resp.Body.Close()
 
-			buf, err := ioutil.ReadAll(resp.Body)
+			buf, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 
 			for _, re := range tt.reMatch {

--- a/ceph/pool_usage_test.go
+++ b/ceph/pool_usage_test.go
@@ -16,7 +16,7 @@ package ceph
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -213,7 +213,7 @@ func TestPoolUsageCollector(t *testing.T) {
 			require.NoError(t, err)
 			defer resp.Body.Close()
 
-			buf, err := ioutil.ReadAll(resp.Body)
+			buf, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 
 			for _, re := range tt.reMatch {

--- a/ceph/rbd_mirror_status_test.go
+++ b/ceph/rbd_mirror_status_test.go
@@ -15,7 +15,7 @@
 package ceph
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -153,7 +153,7 @@ func TestRbdMirrorStatusCollector(t *testing.T) {
 			require.NoError(t, err)
 			defer resp.Body.Close()
 
-			buf, err := ioutil.ReadAll(resp.Body)
+			buf, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 
 			for _, re := range tt.reMatch {

--- a/ceph/rgw.go
+++ b/ceph/rgw.go
@@ -117,9 +117,7 @@ type RGWCollector struct {
 	// ActiveBucketReshard reports the state of reshard operation for a particular bucket.
 	ActiveBucketReshard *prometheus.Desc
 
-	getRGWGCTaskList func(string, string) ([]byte, error)
-
-	bucketList        map[string]struct{}
+	getRGWGCTaskList  func(string, string) ([]byte, error)
 	getRGWReshardList func(string, string) ([]byte, error)
 }
 
@@ -135,7 +133,6 @@ func NewRGWCollector(exporter *Exporter, background bool) *RGWCollector {
 		logger:            exporter.Logger,
 		getRGWGCTaskList:  rgwGetGCTaskList,
 		getRGWReshardList: rgwGetReshardList,
-		bucketList:        map[string]struct{}{},
 
 		GCActiveTasks: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
@@ -274,9 +271,6 @@ func (r *RGWCollector) collect(ch chan<- prometheus.Metric) error {
 	}
 
 	for _, op := range ops {
-		if _, ok := r.bucketList[op.BucketName]; ok {
-			continue
-		}
 		ch <- prometheus.MustNewConstMetric(
 			r.ActiveBucketReshard,
 			prometheus.GaugeValue,

--- a/ceph/rgw_test.go
+++ b/ceph/rgw_test.go
@@ -17,7 +17,6 @@ package ceph
 import (
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -162,7 +161,7 @@ func TestRGWGC(t *testing.T) {
 			require.NoError(t, err)
 			defer resp.Body.Close()
 
-			buf, err := ioutil.ReadAll(resp.Body)
+			buf, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 
 			for _, re := range tt.reMatch {

--- a/ceph/version.go
+++ b/ceph/version.go
@@ -35,14 +35,17 @@ var (
 	// ErrInvalidVersion indicates that the given version string was invalid
 	ErrInvalidVersion = errors.New("invalid version")
 
-	// Nautilus is the *Version at which Ceph nautilus was released
+	// Nautilus is the *Version at which Ceph Nautilus was released.
 	Nautilus = &Version{Major: 14, Minor: 2, Patch: 0, Revision: 0, Commit: ""}
 
-	// Octopus is the *Version at which Ceph octopus was released
+	// Octopus is the *Version at which Ceph Octopus was released.
 	Octopus = &Version{Major: 15, Minor: 2, Patch: 0, Revision: 0, Commit: ""}
 
-	// Pacific is the *Version at which Ceph pacific was released
+	// Pacific is the *Version at which Ceph Pacific was released.
 	Pacific = &Version{Major: 16, Minor: 2, Patch: 0, Revision: 0, Commit: ""}
+
+	// Quincy is the *Version at which Ceph Quincy was released.
+	Quincy = &Version{Major: 17, Minor: 2, Patch: 0, Revision: 0, Commit: ""}
 )
 
 // IsAtLeast returns true if the version is at least as new as the given constraint

--- a/config.go
+++ b/config.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 
 	"gopkg.in/yaml.v2"
@@ -39,7 +38,7 @@ func fileExists(path string) bool {
 }
 
 func ParseConfig(p string) (*Config, error) {
-	cfgData, err := ioutil.ReadFile(p)
+	cfgData, err := os.ReadFile(p)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/digitalocean/ceph_exporter
+module github.com/coreweave/ceph_exporter
 
 go 1.20
 

--- a/main.go
+++ b/main.go
@@ -28,8 +28,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 
-	"github.com/digitalocean/ceph_exporter/ceph"
-	"github.com/digitalocean/ceph_exporter/rados"
+	"github.com/coreweave/ceph_exporter/ceph"
+	"github.com/coreweave/ceph_exporter/rados"
 )
 
 const (

--- a/rados/rados.go
+++ b/rados/rados.go
@@ -23,7 +23,7 @@ import (
 	"github.com/ceph/go-ceph/rados"
 	"github.com/sirupsen/logrus"
 
-	"github.com/digitalocean/ceph_exporter/ceph"
+	"github.com/coreweave/ceph_exporter/ceph"
 )
 
 // RadosConn implements the Conn interface with the underlying *rados.Conn


### PR DESCRIPTION
This adds ability to scrape RGW reshard stats from Ceph exporter. It also displays the active count of ongoing reshards within a given cluster.
