### PR TITLE
rgw: add user to perform rgw operations with

### DIFF
--- a/ceph/rgw.go
+++ b/ceph/rgw.go
@@ -129,6 +129,7 @@ func NewRGWCollector(exporter *Exporter, background bool) *RGWCollector {
 
 	rgw := &RGWCollector{
 		config:            exporter.Config,
+		user:              exporter.User,
 		background:        background,
 		logger:            exporter.Logger,
 		getRGWGCTaskList:  rgwGetGCTaskList,


### PR DESCRIPTION
RGW operations have never worked as expected historically with ceph-exporter because apparently the ceph user was never correctly passed in.