### PR TITLE
mds: initial pr for mds support

### DIFF
--- a/ceph/mds.go
+++ b/ceph/mds.go
@@ -1,0 +1,173 @@
+package ceph
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	cephCmd                      = "/usr/bin/ceph"
+	mdsBackgroundCollectInterval = 5 * time.Minute
+)
+
+const (
+	MDSModeDisabled   = 0
+	MDSModeForeground = 1
+	MDSModeBackground = 2
+)
+
+type mdsStat struct {
+	FSMap struct {
+		Filesystems []struct {
+			MDSMap struct {
+				FSName string `json:"fs_name"`
+				Info   map[string]struct {
+					GID   uint   `json:"gid"`
+					Name  string `json:"name"`
+					Rank  int    `json:"rank"`
+					State string `json:"state"`
+				} `json:"info"`
+			} `json:"mdsmap"`
+		} `json:"filesystems"`
+	} `json:"fsmap"`
+}
+
+// runMDSStat will run mds stat and get all info from the MDSs within the ceph cluster.
+func runMDSStat(config, user string) ([]byte, error) {
+	var (
+		out []byte
+		err error
+	)
+
+	if out, err = exec.Command(cephCmd, "-c", config, "-n", fmt.Sprintf("client.%s", user), "mds", "stat", "--format", "json").Output(); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+// MDSCollector collects metrics from the MDS daemons.
+type MDSCollector struct {
+	config     string
+	user       string
+	background bool
+	logger     *logrus.Logger
+
+	// MDSState reports the state of MDS process running.
+	MDSState *prometheus.Desc
+
+	runMDSStatFn func(string, string) ([]byte, error)
+}
+
+// NewMDSCollector creates an instance of the MDSCollector and instantiates
+// the individual metrics that we can collect from the MDS daemons.
+func NewMDSCollector(exporter *Exporter, background bool) *MDSCollector {
+	labels := make(prometheus.Labels)
+	labels["cluster"] = exporter.Cluster
+
+	mds := &MDSCollector{
+		config:       exporter.Config,
+		user:         exporter.User,
+		background:   background,
+		logger:       exporter.Logger,
+		runMDSStatFn: runMDSStat,
+
+		MDSState: prometheus.NewDesc(
+			fmt.Sprintf("%s_%s", cephNamespace, "mds_daemon_state"),
+			"MDS Daemon State",
+			[]string{"fs", "name", "rank", "state"},
+			labels,
+		),
+	}
+
+	return mds
+}
+
+func (m *MDSCollector) collectorList() []prometheus.Collector {
+	return []prometheus.Collector{}
+}
+
+func (m *MDSCollector) descriptorList() []*prometheus.Desc {
+	return []*prometheus.Desc{
+		m.MDSState,
+	}
+}
+
+func (m *MDSCollector) backgroundCollect(ch chan<- prometheus.Metric) error {
+	for {
+		m.logger.WithField("background", m.background).Debug("collecting MDS stats")
+		err := m.collect(ch)
+		if err != nil {
+			m.logger.WithField("background", m.background).WithError(err).Error("error collecting MDS stats")
+		}
+		time.Sleep(mdsBackgroundCollectInterval)
+	}
+}
+
+func (m *MDSCollector) collect(ch chan<- prometheus.Metric) error {
+	data, err := m.runMDSStatFn(m.config, m.user)
+	if err != nil {
+		return fmt.Errorf("failed getting mds stat: %w", err)
+	}
+
+	ms := &mdsStat{}
+
+	err = json.Unmarshal(data, ms)
+	if err != nil {
+		return fmt.Errorf("failed unmarshalling mds stat json: %w", err)
+	}
+
+	for _, fs := range ms.FSMap.Filesystems {
+		for _, info := range fs.MDSMap.Info {
+			ch <- prometheus.MustNewConstMetric(
+				m.MDSState,
+				prometheus.GaugeValue,
+				float64(1),
+				fs.MDSMap.FSName,
+				info.Name,
+				strconv.Itoa(info.Rank),
+				info.State,
+			)
+		}
+	}
+
+	return nil
+}
+
+// Describe sends the descriptors of each MDSCollector related metrics we have defined
+// to the provided prometheus channel.
+func (m *MDSCollector) Describe(ch chan<- *prometheus.Desc) {
+	for _, metric := range m.collectorList() {
+		metric.Describe(ch)
+	}
+
+	for _, metric := range m.descriptorList() {
+		ch <- metric
+	}
+}
+
+// Collect sends all the collected metrics to the provided prometheus channel.
+// It requires the caller to handle synchronization.
+func (m *MDSCollector) Collect(ch chan<- prometheus.Metric, version *Version) {
+	if !m.background {
+		m.logger.WithField("background", m.background).Debug("collecting MDS stats")
+		err := m.collect(ch)
+		if err != nil {
+			m.logger.WithField("background", m.background).WithError(err).Error("error collecting MDS stats")
+		}
+	}
+
+	if m.background {
+		go m.backgroundCollect(ch)
+	}
+
+	for _, metric := range m.collectorList() {
+		metric.Collect(ch)
+	}
+}

--- a/ceph/mds_test.go
+++ b/ceph/mds_test.go
@@ -1,0 +1,136 @@
+package ceph
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMDSStats(t *testing.T) {
+	for _, tt := range []struct {
+		input     []byte
+		version   string
+		reMatch   []*regexp.Regexp
+		reUnmatch []*regexp.Regexp
+	}{
+		{
+			input: []byte(`
+			{
+				"fsmap": {
+				  "filesystems": [
+					{
+					"mdsmap": {
+					  "max_mds": 2,
+					  "info": {
+						"gid_19706291": {
+						  "gid": 1970629,
+						  "name": "MDS-daemonC",
+						  "rank": 1,
+						  "state": "up:active"
+						},
+						  "gid_19706292": {
+							"gid": 1970629,
+							"name": "MDS-daemonD",
+							"rank": 2,
+							"state": "up:standby-replay"
+						  }
+						},
+					  "data_pools": [
+						1
+					  ],
+					  "metadata_pool": 2,
+					  "enabled": true,
+					  "fs_name": "cephfs-1",
+					  "balancer": "",
+					  "standby_count_wanted": 1
+					},
+					"id": 2
+				  },
+					{
+					  "mdsmap": {
+						"max_mds": 2,
+						"info": {
+						  "gid_19706293": {
+							"gid": 1970629,
+							"name": "MDS-daemonA",
+							"rank": 1,
+							"state": "up:active"
+						  },
+							"gid_19706294": {
+							  "gid": 1970629,
+							  "name": "MDS-daemonB",
+							  "rank": 2,
+							  "state": "up:standby-replay"
+							}
+						  },
+						"data_pools": [
+						  1
+						],
+						"metadata_pool": 2,
+						"enabled": true,
+						"fs_name": "cephfs-2",
+						"balancer": "",
+						"standby_count_wanted": 1
+					  },
+					  "id": 2
+					}
+			]
+		}
+	}
+`),
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
+			reMatch: []*regexp.Regexp{
+				regexp.MustCompile(`ceph_mds_daemon_state{cluster="ceph",fs="cephfs-1",name="MDS-daemonC",rank="1",state="up:active"} 1`),
+				regexp.MustCompile(`ceph_mds_daemon_state{cluster="ceph",fs="cephfs-1",name="MDS-daemonD",rank="2",state="up:standby-replay"} 1`),
+				regexp.MustCompile(`ceph_mds_daemon_state{cluster="ceph",fs="cephfs-2",name="MDS-daemonA",rank="1",state="up:active"} 1`),
+				regexp.MustCompile(`ceph_mds_daemon_state{cluster="ceph",fs="cephfs-2",name="MDS-daemonB",rank="2",state="up:standby-replay"} 1`),
+			},
+		},
+	} {
+		func() {
+			conn := setupVersionMocks(tt.version, "{}")
+
+			e := &Exporter{Conn: conn, Cluster: "ceph", Logger: logrus.New()}
+			e.cc = map[string]versionedCollector{
+				"mds": NewMDSCollector(e, false),
+			}
+
+			e.cc["mds"].(*MDSCollector).runMDSStatFn = func(cluster, user string) ([]byte, error) {
+				if tt.input != nil {
+					return tt.input, nil
+				}
+				return nil, errors.New("fake error")
+			}
+
+			err := prometheus.Register(e)
+			require.NoError(t, err)
+			defer prometheus.Unregister(e)
+
+			server := httptest.NewServer(promhttp.Handler())
+			defer server.Close()
+
+			resp, err := http.Get(server.URL)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			buf, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			for _, re := range tt.reMatch {
+				require.True(t, re.Match(buf))
+			}
+
+			for _, re := range tt.reUnmatch {
+				require.False(t, re.Match(buf))
+			}
+		}()
+	}
+}

--- a/ceph/mds_test.go
+++ b/ceph/mds_test.go
@@ -1,6 +1,7 @@
 package ceph
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -103,7 +104,7 @@ func TestMDSStats(t *testing.T) {
 				"mds": NewMDSCollector(e, false),
 			}
 
-			e.cc["mds"].(*MDSCollector).runMDSStatFn = func(cluster, user string) ([]byte, error) {
+			e.cc["mds"].(*MDSCollector).runMDSStatFn = func(_ context.Context, cluster, user string) ([]byte, error) {
 				if tt.input != nil {
 					return tt.input, nil
 				}

--- a/main.go
+++ b/main.go
@@ -74,6 +74,7 @@ func main() {
 		metricsPath    = envflag.String("TELEMETRY_PATH", "/metrics", "URL path for surfacing metrics to Prometheus")
 		exporterConfig = envflag.String("EXPORTER_CONFIG", "/etc/ceph/exporter.yml", "Path to ceph_exporter config")
 		rgwMode        = envflag.Int("RGW_MODE", 0, "Enable collection of stats from RGW (0:disabled 1:enabled 2:background)")
+		mdsMode        = envflag.Int("MDS_MODE", 0, "Enable collection of stats from MDS (0:disabled 1:enabled 2:background)")
 
 		logLevel = envflag.String("LOG_LEVEL", "info", "Logging level. One of: [trace, debug, info, warn, error, fatal, panic]")
 
@@ -136,6 +137,7 @@ func main() {
 			cluster.ConfigFile,
 			cluster.User,
 			*rgwMode,
+			*mdsMode,
 			logger))
 
 		logger.WithField("cluster", cluster.ClusterLabel).Info("exporting cluster")


### PR DESCRIPTION
This should add the initial MDS support required to start scraping the critical MDS metrics. This change specifically surfaces the daemon state that we can alert on and/or track changes across.