### PR TITLE
mds: add slow/blocked ops tracking

### DIFF
--- a/ceph/mds.go
+++ b/ceph/mds.go
@@ -3,9 +3,11 @@ package ceph
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -44,6 +46,21 @@ func runMDSStat(ctx context.Context, config, user string) ([]byte, error) {
 	return exec.CommandContext(ctx, cephCmd, "-c", config, "-n", fmt.Sprintf("client.%s", user), "mds", "stat", "--format", "json").Output()
 }
 
+// runCephHealthDetail will run health detail and get info specific to MDSs within the ceph cluster.
+func runCephHealthDetail(ctx context.Context, config, user string) ([]byte, error) {
+	return exec.CommandContext(ctx, cephCmd, "-c", config, "-n", fmt.Sprintf("client.%s", user), "health", "detail", "--format", "json").Output()
+}
+
+// runMDSStatus will run status command on the MDS to get it's info.
+func runMDSStatus(ctx context.Context, config, user, mds string) ([]byte, error) {
+	return exec.CommandContext(ctx, cephCmd, "-c", config, "-n", "tell", mds, "status").Output()
+}
+
+// runBlockedOpsCheck will run blocked ops on MDSs and get any ops that are blocked for that MDS.
+func runBlockedOpsCheck(ctx context.Context, config, user, mds string) ([]byte, error) {
+	return exec.CommandContext(ctx, cephCmd, "-c", config, "-n", "tell", mds, "dump_blocked_ops").Output()
+}
+
 // MDSCollector collects metrics from the MDS daemons.
 type MDSCollector struct {
 	config     string
@@ -55,7 +72,13 @@ type MDSCollector struct {
 	// MDSState reports the state of MDS process running.
 	MDSState *prometheus.Desc
 
-	runMDSStatFn func(context.Context, string, string) ([]byte, error)
+	// MDSBlockedOPs reports the slow or blocked ops on an MDS.
+	MDSBlockedOps *prometheus.Desc
+
+	runMDSStatFn          func(context.Context, string, string) ([]byte, error)
+	runCephHealthDetailFn func(context.Context, string, string) ([]byte, error)
+	runMDSStatusFn        func(context.Context, string, string, string) ([]byte, error)
+	runBlockedOpsCheckFn  func(context.Context, string, string, string) ([]byte, error)
 }
 
 // NewMDSCollector creates an instance of the MDSCollector and instantiates
@@ -65,17 +88,26 @@ func NewMDSCollector(exporter *Exporter, background bool) *MDSCollector {
 	labels["cluster"] = exporter.Cluster
 
 	mds := &MDSCollector{
-		config:       exporter.Config,
-		user:         exporter.User,
-		background:   background,
-		logger:       exporter.Logger,
-		ch:           make(chan prometheus.Metric, 100),
-		runMDSStatFn: runMDSStat,
+		config:                exporter.Config,
+		user:                  exporter.User,
+		background:            background,
+		logger:                exporter.Logger,
+		ch:                    make(chan prometheus.Metric, 100),
+		runMDSStatFn:          runMDSStat,
+		runCephHealthDetailFn: runCephHealthDetail,
+		runMDSStatusFn:        runMDSStatus,
+		runBlockedOpsCheckFn:  runBlockedOpsCheck,
 
 		MDSState: prometheus.NewDesc(
 			fmt.Sprintf("%s_%s", cephNamespace, "mds_daemon_state"),
 			"MDS Daemon State",
 			[]string{"fs", "name", "rank", "state"},
+			labels,
+		),
+		MDSBlockedOps: prometheus.NewDesc(
+			fmt.Sprintf("%s_%s", cephNamespace, "mds_blocked_ops"),
+			"MDS Blocked Ops",
+			[]string{"fs", "name", "state", "optype", "fs_optype", "flag_point"},
 			labels,
 		),
 	}
@@ -106,7 +138,7 @@ func (m *MDSCollector) backgroundCollect() {
 }
 
 func (m *MDSCollector) collect() error {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 
 	data, err := m.runMDSStatFn(ctx, m.config, m.user)
@@ -137,6 +169,8 @@ func (m *MDSCollector) collect() error {
 			}
 		}
 	}
+
+	m.collectMDSSlowOps()
 
 	return nil
 }
@@ -182,4 +216,230 @@ func (m *MDSCollector) Collect(ch chan<- prometheus.Metric, version *Version) {
 			return
 		}
 	}
+}
+
+type healthDetailCheck struct {
+	Status string `json:"status"`
+	Checks map[string]struct {
+		Severity string `json:"severity"`
+		Summary  struct {
+			Message string `json:"message"`
+			Count   int    `json:"count"`
+		} `json:"summary"`
+		Detail []struct {
+			Message string `json:"message"`
+		} `json:"detail"`
+		Muted bool `json:"muted"`
+	} `json:"checks"`
+}
+
+type mdsStatus struct {
+	ClusterFsid        string  `json:"cluster_fsid"`
+	Whoami             int     `json:"whoami"`
+	ID                 int64   `json:"id"`
+	WantState          string  `json:"want_state"`
+	State              string  `json:"state"`
+	FsName             string  `json:"fs_name"`
+	RankUptime         float64 `json:"rank_uptime"`
+	MdsmapEpoch        int     `json:"mdsmap_epoch"`
+	OsdmapEpoch        int     `json:"osdmap_epoch"`
+	OsdmapEpochBarrier int     `json:"osdmap_epoch_barrier"`
+	Uptime             float64 `json:"uptime"`
+}
+
+type mdsSlowOp struct {
+	Ops []struct {
+		// Custom fields for easy parsing by caller.
+		MDSName, CephFSOpType string
+
+		// CephFS fields.
+		Description string  `json:"description"`
+		InitiatedAt string  `json:"initiated_at"`
+		Age         float64 `json:"age"`
+		Duration    float64 `json:"duration"`
+		TypeData    struct {
+			FlagPoint  string `json:"flag_point"`
+			Reqid      string `json:"reqid"`
+			OpType     string `json:"op_type"`
+			ClientInfo struct {
+				Client string `json:"client"`
+				Tid    int    `json:"tid"`
+			} `json:"client_info"`
+			Events []struct {
+				Time  string `json:"time"`
+				Event string `json:"event"`
+			} `json:"events"`
+		} `json:"type_data,omitempty"`
+	} `json:"ops"`
+	ComplaintTime int `json:"complaint_time"`
+	NumBlockedOps int `json:"num_blocked_ops"`
+}
+
+func (m *MDSCollector) collectMDSSlowOps() {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	data, err := runCephHealthDetail(ctx, m.config, m.user)
+	if err != nil {
+		m.logger.WithError(err).Error("failed getting health detail")
+		return
+	}
+
+	hc := &healthDetailCheck{}
+
+	err = json.Unmarshal(data, hc)
+	if err != nil {
+		m.logger.WithError(err).Error("failed unmarshalling health detail")
+		return
+	}
+
+	check, ok := hc.Checks["MDS_SLOW_REQUEST"]
+	if !ok {
+		// No slow requests! Yay!
+		return
+	}
+
+	for _, cc := range check.Detail {
+		mdsNameParts := strings.Split(cc.Message, "(")
+		if len(mdsNameParts) != 2 {
+			m.logger.WithError(
+				errors.New("incorrect part count"),
+			).WithFields(logrus.Fields{
+				"message": cc.Message,
+			}).Error("invalid mds slow request message found, check syntax")
+			continue
+		}
+
+		mdsName := mdsNameParts[0]
+
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+		defer cancel()
+
+		data, err := runMDSStatus(ctx, m.config, m.user, mdsName)
+		if err != nil {
+			m.logger.WithField("mds", mdsName).WithError(err).Error("failed getting status from mds")
+			return
+		}
+
+		mss := &mdsStatus{}
+
+		err = json.Unmarshal(data, mss)
+		if err != nil {
+			m.logger.WithField("mds", mdsName).WithError(err).Error("failed unmarshalling mds status")
+			return
+		}
+
+		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Minute)
+		defer cancel()
+
+		data, err = runBlockedOpsCheck(ctx, m.config, m.user, mdsName)
+		if err != nil {
+			m.logger.WithField("mds", mdsName).WithError(err).Error("failed getting blocked ops from mds")
+			return
+		}
+
+		mso := &mdsSlowOp{}
+
+		err = json.Unmarshal(data, mso)
+		if err != nil {
+			m.logger.WithField("mds", mdsName).WithError(err).Error("failed unmarshalling mds blocked ops")
+			return
+		}
+
+		for _, op := range mso.Ops {
+			if op.TypeData.OpType == "client_request" {
+				opd, err := extractOpFromDescription(op.Description)
+				if err != nil {
+					m.logger.WithField("mds", mdsName).WithError(err).Error("failed parsing blocked ops description")
+					continue
+				}
+
+				select {
+				case m.ch <- prometheus.MustNewConstMetric(
+					m.MDSBlockedOps,
+					prometheus.CounterValue,
+					1,
+					mss.FsName,
+					mdsName,
+					mss.State,
+					op.TypeData.OpType,
+					opd.fsOpType,
+					op.TypeData.FlagPoint,
+				):
+				default:
+				}
+
+				continue
+			}
+
+			select {
+			case m.ch <- prometheus.MustNewConstMetric(
+				m.MDSBlockedOps,
+				prometheus.CounterValue,
+				1,
+				mss.FsName,
+				mdsName,
+				mss.State,
+				op.TypeData.OpType,
+				"",
+				op.TypeData.FlagPoint,
+			):
+			default:
+			}
+		}
+
+	}
+}
+
+type opDesc struct {
+	fsOpType string
+	inode    string
+	clientID string
+}
+
+// extractOpFromDescription is designed to extract the fs optype from a given slow/blocked
+// ops description.
+//
+// For e.g. given the description as follows:
+//
+//	"client_request(client.20001974182:344151 rmdir #0x10000000030/72a26231-ac24-4f69-9350-8ebc5444c9ea 2024-02-13T22:11:00.196767+0000 caller_uid=0, caller_gid=0{})"
+//
+// we should be able to extract the following fs optype out of it:
+//
+//	"rmdir"
+func extractOpFromDescription(desc string) (*opDesc, error) {
+	parts := strings.Fields(desc)
+	if len(parts) < 4 {
+		return nil, fmt.Errorf("invalid fs description: %q", desc)
+	}
+
+	fsoptype, inode := parts[1], parts[2]
+	inode = strings.TrimLeft(inode, "#0x")
+	inode = strings.Split(inode, "/")[0]
+
+	_, err := strconv.ParseUint(inode, 16, 14)
+	if err != nil {
+		return nil, fmt.Errorf("invalid inode, expected hex instead got %q: %w", inode, err)
+	}
+
+	clientIDParts := strings.Split(parts[0], "(")
+	if len(clientIDParts) != 2 {
+		return nil, fmt.Errorf("invalid client request format: %q", parts[0])
+	}
+
+	clientIDParts = strings.Split(clientIDParts[1], ":")
+	if len(clientIDParts) != 2 {
+		return nil, fmt.Errorf("invalid client id format: %q", clientIDParts[1])
+	}
+
+	clientIDParts = strings.Split(clientIDParts[0], ".")
+	if len(clientIDParts) != 2 {
+		return nil, fmt.Errorf("invalid client id string: %q", clientIDParts[0])
+	}
+
+	return &opDesc{
+		fsOpType: fsoptype,
+		inode:    inode,
+		clientID: clientIDParts[1],
+	}, nil
 }

--- a/ceph/mds_test.go
+++ b/ceph/mds_test.go
@@ -135,3 +135,313 @@ func TestMDSStats(t *testing.T) {
 		}()
 	}
 }
+
+func TestMDSBlockedOps(t *testing.T) {
+	for _, tt := range []struct {
+		mdsStat      []byte
+		healthDetail []byte
+		blockedOps   []byte
+		mdsStatus    []byte
+		version      string
+		reMatch      []*regexp.Regexp
+		reUnmatch    []*regexp.Regexp
+	}{
+		{
+			mdsStat: []byte(`
+			{
+				"fsmap": {
+				  "filesystems": [
+					{
+					"mdsmap": {
+					  "max_mds": 2,
+					  "info": {
+						"gid_19706291": {
+						  "gid": 1970629,
+						  "name": "MDS-daemonC",
+						  "rank": 1,
+						  "state": "up:active"
+						},
+						  "gid_19706292": {
+							"gid": 1970629,
+							"name": "MDS-daemonD",
+							"rank": 2,
+							"state": "up:standby-replay"
+						  }
+						},
+					  "data_pools": [
+						1
+					  ],
+					  "metadata_pool": 2,
+					  "enabled": true,
+					  "fs_name": "cephfs-1",
+					  "balancer": "",
+					  "standby_count_wanted": 1
+					},
+					"id": 2
+				  },
+					{
+					  "mdsmap": {
+						"max_mds": 2,
+						"info": {
+						  "gid_19706293": {
+							"gid": 1970629,
+							"name": "MDS-daemonA",
+							"rank": 1,
+							"state": "up:active"
+						  },
+							"gid_19706294": {
+							  "gid": 1970629,
+							  "name": "MDS-daemonB",
+							  "rank": 2,
+							  "state": "up:standby-replay"
+							}
+						  },
+						"data_pools": [
+						  1
+						],
+						"metadata_pool": 2,
+						"enabled": true,
+						"fs_name": "cephfs-2",
+						"balancer": "",
+						"standby_count_wanted": 1
+					  },
+					  "id": 2
+					}
+			]
+		}
+	}
+`),
+			healthDetail: []byte(`
+			{
+				"status": "HEALTH_WARN",
+				"checks": {
+					"MDS_SLOW_REQUEST": {
+						"severity": "HEALTH_WARN",
+						"summary": {
+							"message": "1 MDSs report slow requests",
+							"count": 1
+						},
+						"detail": [
+							{
+								"message": "mds.nodeA(mds.1): 1 slow requests are blocked > 30 secs"
+							}
+						],
+						"muted": false
+					},
+					"RECENT_CRASH": {
+						"severity": "HEALTH_WARN",
+						"summary": {
+							"message": "1 daemons have recently crashed",
+							"count": 1
+						},
+						"detail": [
+							{
+								"message": "mds.nodeB crashed on host nodeB at 2024-02-13T22:11:00.200261Z"
+							}
+						],
+						"muted": false
+					}
+				}
+			}
+`),
+			blockedOps: []byte(`
+			{
+				"ops": [
+					{
+						"description": "client_request(client.20074182:344151 rmdir #0x10000000030/8ebc5444c9ea 2024-02-13T22:11:00.196767+0000 caller_uid=0, caller_gid=0{})",
+						"initiated_at": "2024-02-13T22:11:00.197241+0000",
+						"age": 148692.11557664501,
+						"duration": 148692.11559661099,
+						"type_data": {
+							"flag_point": "cleaned up request",
+							"reqid": "client.20074182:344151",
+							"op_type": "client_request",
+							"client_info": {
+								"client": "client.20074182",
+								"tid": 344151
+							},
+							"events": [
+								{
+									"time": "2024-02-13T22:11:00.197241+0000",
+									"event": "initiated"
+								},
+								{
+									"time": "2024-02-13T22:11:00.197241+0000",
+									"event": "throttled"
+								},
+								{
+									"time": "2024-02-13T22:11:00.197241+0000",
+									"event": "header_read"
+								},
+								{
+									"time": "2024-02-13T22:11:00.197247+0000",
+									"event": "all_read"
+								},
+								{
+									"time": "2024-02-13T22:11:00.197250+0000",
+									"event": "dispatched"
+								},
+								{
+									"time": "2024-02-13T22:11:00.197331+0000",
+									"event": "failed to wrlock, waiting"
+								},
+								{
+									"time": "2024-02-13T22:11:00.197476+0000",
+									"event": "failed to xlock, waiting"
+								},
+								{
+									"time": "2024-02-13T22:11:00.197548+0000",
+									"event": "acquired locks"
+								},
+								{
+									"time": "2024-02-14T07:47:59.551074+0000",
+									"event": "killing request"
+								},
+								{
+									"time": "2024-02-14T07:47:59.551135+0000",
+									"event": "cleaned up request"
+								}
+							]
+						}
+					}
+				],
+				"complaint_time": 30,
+				"num_blocked_ops": 1
+			}
+`),
+			mdsStatus: []byte(`
+			{
+				"cluster_fsid": "xxxx",
+				"whoami": 1,
+				"id": 20004801,
+				"want_state": "up:active",
+				"state": "up:active",
+				"fs_name": "fsA",
+				"rank_uptime": 160259.41429652399,
+				"mdsmap_epoch": 881925,
+				"osdmap_epoch": 222331815,
+				"osdmap_epoch_barrier": 222331815,
+				"uptime": 163199.411784772
+			}
+`),
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
+			reMatch: []*regexp.Regexp{
+				regexp.MustCompile(`ceph_mds_blocked_ops{cluster="ceph",flag_point="cleaned up request",fs="fsA",fs_optype="rmdir",name="mds.nodeA",optype="client_request",state="up:active"} 1`),
+			},
+		},
+	} {
+		func() {
+			conn := setupVersionMocks(tt.version, "{}")
+
+			e := &Exporter{Conn: conn, Cluster: "ceph", Logger: logrus.New()}
+			mdsc := NewMDSCollector(e, false)
+			mdsc.runCephHealthDetailFn = func(_ context.Context, cluster, user string) ([]byte, error) {
+				if tt.healthDetail != nil {
+					return tt.healthDetail, nil
+				}
+				return nil, errors.New("fake error")
+			}
+			mdsc.runBlockedOpsCheckFn = func(_ context.Context, cluster, user, mds string) ([]byte, error) {
+				if tt.blockedOps != nil {
+					return tt.blockedOps, nil
+				}
+				return nil, errors.New("fake error")
+			}
+			mdsc.runMDSStatusFn = func(_ context.Context, cluster, user, mds string) ([]byte, error) {
+				if tt.mdsStatus != nil {
+					return tt.mdsStatus, nil
+				}
+				return nil, errors.New("fake error")
+			}
+			mdsc.runMDSStatFn = func(_ context.Context, cluster, user string) ([]byte, error) {
+				if tt.mdsStat != nil {
+					return tt.mdsStat, nil
+				}
+				return nil, errors.New("fake error")
+			}
+
+			e.cc = map[string]versionedCollector{
+				"mds": mdsc,
+			}
+
+			err := prometheus.Register(e)
+			require.NoError(t, err)
+			defer prometheus.Unregister(e)
+
+			server := httptest.NewServer(promhttp.Handler())
+			defer server.Close()
+
+			resp, err := http.Get(server.URL)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			buf, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			for _, re := range tt.reMatch {
+				require.True(t, re.Match(buf))
+			}
+
+			for _, re := range tt.reUnmatch {
+				require.False(t, re.Match(buf))
+			}
+		}()
+	}
+}
+
+func TestExtractOpFromDescription(t *testing.T) {
+	for _, tt := range []struct {
+		input  string
+		errMsg string
+		opd    *opDesc
+	}{
+		{
+			input:  "client_request(client.20001974182:344151 rmdir #0x10000000030/72a26231-ac24-4f69-9350-8ebc5444c9ea 2024-02-13T22:11:00.196767+0000 caller_uid=0, caller_gid=0{})",
+			errMsg: "",
+			opd: &opDesc{
+				fsOpType: "rmdir",
+				inode:    "0x10000000030",
+				clientID: "20001974182",
+			},
+		},
+		{
+			input:  "client_request(client.20001974182:344151rmdir#0x10000000030ZZZZ/72a26231-ac24-4f69-9350-8ebc5444c9ea2024-02-13T22:11:00.196767+0000caller_uid=0, caller_gid=0{})",
+			errMsg: `invalid fs description`,
+			opd:    nil,
+		},
+		{
+			input:  "client_request(client.20001974182:344151 rmdir #0x10000000030ZZZZ/72a26231-ac24-4f69-9350-8ebc5444c9ea 2024-02-13T22:11:00.196767+0000 caller_uid=0, caller_gid=0{})",
+			errMsg: `invalid inode, expected hex instead got "0x10000000030ZZZZ": strconv.ParseUint: parsing "10000000030ZZZZ": invalid syntax`,
+			opd:    nil,
+		},
+		{
+			input:  "client_request[client.20001974182:344151 rmdir #0x10000000030/72a26231-ac24-4f69-9350-8ebc5444c9ea 2024-02-13T22:11:00.196767+0000 caller_uid=0, caller_gid=0{})",
+			errMsg: `invalid client request format`,
+			opd:    nil,
+		},
+		{
+			input:  "client_request(client.20001974182/344151 rmdir #0x10000000030/72a26231-ac24-4f69-9350-8ebc5444c9ea 2024-02-13T22:11:00.196767+0000 caller_uid=0, caller_gid=0{})",
+			errMsg: `invalid client id format`,
+			opd:    nil,
+		},
+		{
+			input:  "client_request(client|20001974182:344151 rmdir #0x10000000030/72a26231-ac24-4f69-9350-8ebc5444c9ea 2024-02-13T22:11:00.196767+0000 caller_uid=0, caller_gid=0{})",
+			errMsg: `nvalid client id string`,
+			opd:    nil,
+		},
+	} {
+		opd, err := extractOpFromDescription(tt.input)
+		if tt.errMsg != "" {
+			require.NotNil(t, err)
+		}
+		if tt.errMsg == "" {
+			require.NoError(t, err)
+		}
+		if err != nil {
+			require.ErrorContains(t, err, tt.errMsg)
+		}
+		if tt.opd != nil {
+			require.Equal(t, tt.opd, opd)
+		}
+	}
+}


### PR DESCRIPTION
This change adds a way to track slow/blocked ops on MDSs in a way that we can query, dashboard and alert on if needed. We should be able to identify which MDSs have the most slow ops on and what type of ops those exactly are so we can group them together (rmdir, unlink, create, etc.). If this doesn't seem to impact the tsdb (due to using const-metrics) we should see if we can add in the inode as well (since that can trigger time-series explosion but will be extremely informative).


