### PR TITLE
mds: expose inode information to avoid duplicates

### DIFF
--- a/ceph/mds.go
+++ b/ceph/mds.go
@@ -107,7 +107,7 @@ func NewMDSCollector(exporter *Exporter, background bool) *MDSCollector {
 		MDSBlockedOps: prometheus.NewDesc(
 			fmt.Sprintf("%s_%s", cephNamespace, "mds_blocked_ops"),
 			"MDS Blocked Ops",
-			[]string{"fs", "name", "state", "optype", "fs_optype", "flag_point"},
+			[]string{"fs", "name", "state", "optype", "fs_optype", "flag_point", "inode"},
 			labels,
 		),
 	}
@@ -365,6 +365,7 @@ func (m *MDSCollector) collectMDSSlowOps() {
 					op.TypeData.OpType,
 					opd.fsOpType,
 					op.TypeData.FlagPoint,
+					opd.inode,
 				):
 				default:
 				}
@@ -383,6 +384,7 @@ func (m *MDSCollector) collectMDSSlowOps() {
 				op.TypeData.OpType,
 				"",
 				op.TypeData.FlagPoint,
+				"",
 			):
 			default:
 			}

--- a/ceph/mds_test.go
+++ b/ceph/mds_test.go
@@ -326,7 +326,7 @@ func TestMDSBlockedOps(t *testing.T) {
 `),
 			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
-				regexp.MustCompile(`ceph_mds_blocked_ops{cluster="ceph",flag_point="cleaned up request",fs="fsA",fs_optype="rmdir",name="mds.nodeA",optype="client_request",state="up:active"} 1`),
+				regexp.MustCompile(`ceph_mds_blocked_ops{cluster="ceph",flag_point="cleaned up request",fs="fsA",fs_optype="rmdir",inode="0x10000000030",name="mds.nodeA",optype="client_request",state="up:active"} 1`),
 			},
 		},
 	} {


### PR DESCRIPTION
Currently there is a bug where when multiple operations of same `fs_optype` are stuck on the same MDS they are all grouped into one. This change surfaces the inode information of each optype that will also help when troubleshooting.
