### PR TITLE
feat(ceph_exporter): Have the release workflow also publish an image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3.1.0
         with:
@@ -58,3 +61,5 @@ jobs:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,10 @@ on:
     branches:
       - "main"
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   create-releases:
     runs-on: ubuntu-latest
@@ -33,5 +37,28 @@ jobs:
         uses: actions/checkout@v4
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v4
+        id: semantic
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: steps.semantic.outputs.new_release_published == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        if: steps.semantic.outputs.new_release_published == 'true'
+        uses: docker/login-action@v3.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push current version
+        if: steps.semantic.outputs.new_release_published == 'true'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.semantic.outputs.new_release_version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ We build the client with support for nautilus specifically but the binary will w
 ### Docker Hub
 
 The official docker image is available at
-[digitalocean/ceph_exporter](https://hub.docker.com/r/digitalocean/ceph_exporter/).
+[ghcr.io/coreweave/ceph_exporter](https://github.com/coreweave/ceph_exporter/pkgs/container/ceph_exporter).
 
 ### Build From Source
 
@@ -85,20 +85,20 @@ under the default `/etc/ceph` location that Ceph checks for.
 A sample build command would look like:
 
 ```bash
-$ docker build -t digitalocean/ceph_exporter .
+$ docker build -t ghcr.io/coreweave/ceph_exporter .
 ```
 
 A `--build-args TEST=true` flag can be added to the build command above to
 also run Golang's unit tests during build:
 
 ```bash
-docker build -t digitalocean/ceph_exporter . --build-arg TEST=true --no-cache
+docker build -t ghcr.io/coreweave/ceph_exporter . --build-arg TEST=true --no-cache
 ```
 
 You can start running your `ceph_exporter` container now.
 
 ```bash
-$ docker run -v /etc/ceph:/etc/ceph -p=9128:9128 -it digitalocean/ceph_exporter
+$ docker run -v /etc/ceph:/etc/ceph -p=9128:9128 -it ghcr.io/coreweave/ceph_exporter
 ```
 
 You would have to ensure your image can talk over to the monitors. If it needs


### PR DESCRIPTION
This will ensure that a release tag will also auto publish the image associated with the tag. Also adds the gh cache to the build.